### PR TITLE
Use cmake fetchcontent for FTXUI dependency.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "external/FTXUI"]
-	path = external/FTXUI
-	url = https://github.com/ArthurSonzogni/FTXUI.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,26 @@
 cmake_minimum_required(VERSION 3.14)
 
-add_subdirectory(external/FTXUI)
+project(i3-termdialogs)
+include(FetchContent)
 
+# ftxui ------------------------------------------------------------------------
+FetchContent_Declare(ftxui 
+	GIT_REPOSITORY https://github.com/ArthurSonzogni/ftxui
+	GIT_TAG  f506be941ddda760bdc45e1593362b383d77eabd
+)
+FetchContent_GetProperties(ftxui)
+if(NOT ftxui_POPULATED)
+  FetchContent_Populate(ftxui)
+  add_subdirectory(${ftxui_SOURCE_DIR} ${ftxui_BINARY_DIR} EXCLUDE_FROM_ALL)
+endif()
+
+# ALSA -------------------------------------------------------------------------
 find_package(ALSA REQUIRED)
 
-include_directories(${ALSA_INCLUDE_DIRS})
-
+# volume -----------------------------------------------------------------------
 add_executable(volume src/volume.cpp)
-target_link_libraries(volume PUBLIC component ${ALSA_LIBRARY})
+target_link_libraries(volume PRIVATE ftxui::component)
+target_link_libraries(volume PRIVATE ALSA::ALSA)
+
+# C++17 is used. We requires fold expressions at least.
+set_target_properties(volume PROPERTIES CXX_STANDARD 17)

--- a/src/volume.cpp
+++ b/src/volume.cpp
@@ -61,23 +61,37 @@ public:
     VolumeComponent() {};
 
     bool OnEvent(Event event) override {
-        if (event == Event::ArrowUp || event == Event::ArrowRight || event.values[0] == 'k' || event.values[0] == 'l') {
+        if (event == Event::ArrowUp ||
+            event == Event::ArrowRight ||
+            event == Event::Character('k') ||
+            event == Event::Character('l')) {
             on_increase();
+            on_change();
+            return true;
         }
-        else if (event == Event::ArrowDown || event == Event::ArrowLeft || event.values[0] == 'j' || event.values[0] == 'h') {
+        
+        if (event == Event::ArrowDown ||
+            event == Event::ArrowLeft ||
+            event == Event::Character('j') ||
+            event == Event::Character('h')) {
             on_decrease();
+            on_change();
+            return true;
         }
-        else if (event.values[0] == 'q') {
+        
+        if (event == Event::Character('q')) {
             on_escape();
+            on_change();
+            return true;
         }
-        else if (static_cast<char>(event.values[0]) == 'm') {
+
+        if (event == Event::Character('m')) {
             on_mute();
+            on_change();
+            return true;
         }
-        else {
-            return Component::OnEvent(event);
-        }
-        on_change();
-        return true;
+
+        return Component::OnEvent(event);
     }
 
     std::function<void()> on_increase = [](){};


### PR DESCRIPTION
Replace git submodules by cmake fetch content

CMake's FetchContent can be used to download dependencies.
FTXUI can easily be 'updated' by changing the hash.

This updates the code to match latest FTXUI version.