### PR TITLE
Fix 2 bugs.

### DIFF
--- a/src/volume.cpp
+++ b/src/volume.cpp
@@ -90,7 +90,7 @@ public:
         return vbox(gauge(volume),
                     hbox(text(L"→,↑,k,l – vol up") | flex,
                          text(L"←,↓,h,j – vol down") | flex,
-                         text(L"h – mute") | flex,
+                         text(L"m – mute") | flex,
                          text(L"q – exit") | flex));
     }
 
@@ -105,7 +105,7 @@ int main(int argc, const char* argv[]) {
     component.volume = volctl.volume();
     component.on_increase = [&](){ volctl.volume(std::min(1.f, component.volume + 0.03f)); };
     component.on_decrease = [&](){ volctl.volume(std::max(0.f, component.volume - 0.03f)); };
-    component.on_escape = [&](){ screen.ExitLoopClosure(); exit(0); };
+    component.on_escape = screen.ExitLoopClosure();
     component.on_mute = [&](){ volctl.mute_toggle(); };
     component.on_change = [&](){ component.volume = volctl.volume();};
     screen.Loop(&component);


### PR DESCRIPTION
1) In the documentation. It was written 'h' for muting the sound. In
   reality, it should have been 'm'
2) The code for closing was wrong. Screen.ExitClosure() returns a
   function. There are no need to wrap it one more time inside a
   function.